### PR TITLE
Allow Foo::class magic constants.

### DIFF
--- a/src/consumers/ScopeConsumer.php
+++ b/src/consumers/ScopeConsumer.php
@@ -74,7 +74,7 @@ class ScopeConsumer extends Consumer {
         continue;
       }
 
-      if($ttype === T_DOUBLE_COLON) {
+      if ($ttype === T_DOUBLE_COLON) {
         $static_access = true;
         continue;
       }
@@ -160,7 +160,7 @@ class ScopeConsumer extends Consumer {
         $builder->addNamespace((new NamespaceConsumer($this->tq))->getBuilder());
         return;
       case DefinitionType::CLASS_DEF:
-        if($static_access) {
+        if ($static_access) {
           // Foo::class is not a class definition
           return;
         }

--- a/src/consumers/ScopeConsumer.php
+++ b/src/consumers/ScopeConsumer.php
@@ -26,6 +26,7 @@ class ScopeConsumer extends Consumer {
     $scope_depth = 1;
     $visibility = null;
     $static = false;
+    $static_access = false;
     $property_type = null;
     while ($tq->haveTokens() && $scope_depth > 0) {
       list ($token, $ttype) = $tq->shift();
@@ -70,6 +71,11 @@ class ScopeConsumer extends Consumer {
       // I hate you, PHP.
       if ($ttype === T_STRING && strtolower($token) === 'define') {
         $builder->addConstant((new DefineConsumer($tq))->getBuilder());
+        continue;
+      }
+
+      if($ttype === T_DOUBLE_COLON) {
+        $static_access = true;
         continue;
       }
 
@@ -123,11 +129,13 @@ class ScopeConsumer extends Consumer {
           $docblock,
           $visibility,
           $static,
+          $static_access,
         );
         $attrs = Map { };
         $docblock = null;
         $visibility = null;
         $static = false;
+        $static_access = false;
         $property_type = null;
         continue;
       }
@@ -143,6 +151,7 @@ class ScopeConsumer extends Consumer {
     ?string $docblock,
     ?VisibilityToken $visibility,
     bool $static,
+    bool $static_access,
    ): void {
     $this->consumeWhitespace();
 
@@ -151,6 +160,11 @@ class ScopeConsumer extends Consumer {
         $builder->addNamespace((new NamespaceConsumer($this->tq))->getBuilder());
         return;
       case DefinitionType::CLASS_DEF:
+        if($static_access) {
+          // Foo::class is not a class definition
+          return;
+        }
+        // FALLTHROUGH
       case DefinitionType::INTERFACE_DEF:
       case DefinitionType::TRAIT_DEF:
         $builder->addClass(

--- a/tests/NamingTest.php
+++ b/tests/NamingTest.php
@@ -36,4 +36,20 @@ class NamingTest extends \PHPUnit_Framework_TestCase {
       ->map($x ==> $x->getName())
     );
   }
+
+  public function testClassMagicConstant(): void {
+      $data = "<?hh Foo::class;\nclass Foo{}";
+
+      // Make sure that Foo::class tokenizes as T_STRING, T_DOUBLE_COLON, T_CLASS
+      $tokens = token_get_all($data);
+      $this->assertContains([T_CLASS, 'class', 1], $tokens);
+
+      // This could throw because the ; comes after the keyword class
+      $this->assertEquals(
+          'Foo',
+          FileParser::FromData($data)
+          ->getClass('Foo')
+          ->getName()
+      );
+  }
 }


### PR DESCRIPTION
Previously the `class` in `Foo::class` was interpreted as the beginning of a class definition.  This updates the scope consumer to track static access (`::`) and not interpret the `class` keyword as a class definition if it immediately follows a static access.