### PR TITLE
getNamespace should not return nullable

### DIFF
--- a/src/definitions/ScannedBase.php
+++ b/src/definitions/ScannedBase.php
@@ -40,7 +40,7 @@ abstract class ScannedBase {
     return $this->attributes;
   }
 
-  public function getNamespaceName(): ?string {
+  public function getNamespaceName(): string {
     return $this->namespace;
   }
 


### PR DESCRIPTION
I am a clown -- forgot to change this when we decided to return empty string.